### PR TITLE
Remove function to find tabs in config file

### DIFF
--- a/dottle
+++ b/dottle
@@ -444,20 +444,10 @@ install () {
     done < "$CONFIG_FILE"
 }
 
-# check if config file contains tabulators
-check () {
-    if grep "\t" "$CONFIG_FILE" > /dev/null; then
-        output warn "The config file contains tabs. They will be replaced with 4 spaces"
-    fi
-}
-
 # main
 case "$1" in
     --help)
         show_help
-        ;;
-    check)
-        check
         ;;
     install)
         install


### PR DESCRIPTION
@ludat I'm thinking about removing `check()` function, because it doesn't seems much usefull to me. Tabs in config files are [removed anyway while parsing](https://github.com/ludat/dottle/blob/master/dottle#L412-L414), but since you don't modify file itself, i don't see much reason to show warning message.
